### PR TITLE
Parse hashes to support deep interpolation

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -77,9 +77,7 @@ class Hiera
 
             when :hash
               raise("Hiera type mismatch: expected Hash and got %s" % found.class) unless found.is_a?(Hash)
-              answer ||= {}
-              answer = found.merge(answer)
-
+              answer = Backend.parse_answer(found, scope).merge(answer || {})
             else
               answer = Backend.parse_answer(found, scope)
               break


### PR DESCRIPTION
`Hiera::Backend` supports recursively parsing Hashes: https://github.com/puppetlabs/hiera/blob/master/lib/hiera/backend.rb#L137-L144

The module-data backend should support that, too. This was motivated by the desire to have string values inside nested hashes be interpolated, e.g.

``` yaml

---
ruby::version::env:
  Darwin:
    BOXEN_S3_HOST: "%{::boxen_s3_host}"
```

cc @wfarr
