### PR TITLE
Be quieter about the puppet indirector requires

### DIFF
--- a/lib/puppet/indirector/data_binding/hiera.rb
+++ b/lib/puppet/indirector/data_binding/hiera.rb
@@ -5,13 +5,11 @@ require "hiera/scope"
 begin
   require 'puppet/indirector/hiera'
 rescue LoadError => e
-  $stderr.puts "Couldn't require puppet/indirector/hiera, whatever"
-end
-
-begin
-  require "puppet/indirector/code"
-rescue LoadError => e
-  $stderr.puts "Couldn't require puppet/indirector/code, whatever"
+  begin
+    require "puppet/indirector/code"
+  rescue LoadError => e
+    $stderr.puts "Couldn't require either of puppet/indirector/{hiera,code}!"
+  end
 end
 
 


### PR DESCRIPTION
Right now, the "Couldn't require puppet/indirector/_, whatever" output to stderr is confusing and unnecessary in most cases. This is only an issue if *neither_ of the requires succeed. If one succeeds, we should just be quiet.
