### PR TITLE
Use the global scope for environment lookup

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -14,9 +14,9 @@ class Hiera
         default_config = {:hierarchy => ["common"]}
 
         mod = Puppet::Module.find(module_name, environment)
-        
+
         return default_config unless mod
-        
+
         path = mod.path
         module_config = File.join(path, "data", "hiera.yaml")
         config = {}
@@ -49,10 +49,10 @@ class Hiera
           return answer
         end
 
-        config = load_module_config(scope["module_name"], scope["environment"])
+        config = load_module_config(scope["module_name"], scope["::environment"])
 
         unless config["path"]
-          Hiera.debug("Could not find a path to the module '%s' in environment '%s'" % [scope["module_name"], scope["environment"]])
+          Hiera.debug("Could not find a path to the module '%s' in environment '%s'" % [scope["module_name"], scope["::environment"]])
           return answer
         end
 


### PR DESCRIPTION
Modules sometimes have their own "environment" variable, which prior to this change would get looked up by module_data and cause an error. I believe that when module_data looks up environment it really means ::environment.

Obviously modules shouldn't be using the environment variable for their own ends, but this patch makes module_data work with those modules as well.
