### PR TITLE
puppet considers metadata without dependencies to be invalid

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,6 @@
   "project_page": "https://github.com/ripienaar/puppet-module-data",
   "source": "https://github.com/ripienaar/puppet-module-data.git",
   "summary": "A hiera backend to allow the use of data while writing sharable modules",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "dependencies": []
 }


### PR DESCRIPTION
Puppet considers [metadata without dependencies to be invalid](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/module.rb#L120-L125) though it [currently hides this fact from the user](https://github.com/puppetlabs/puppet/pull/3261).
