### PR TITLE
Support the override parameter of the hiera functions.

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -60,6 +60,7 @@ class Hiera
           return answer
         end
 
+        config[:hierarchy].insert(0, order_override) if order_override
         config[:hierarchy].each do |source|
           source = File.join(config["path"], "data", "%s.yaml" % Backend.parse_string(source, scope))
 


### PR DESCRIPTION
Previously the module_data backend simply ignored the optional
override parameter of the hiera lookup function. This change inserts
the override into the top of the hierarchy, as specified in the puppet
doucmentation:

https://docs.puppetlabs.com/references/latest/function.html#hiera