### PR TITLE
Allow fallback to Puppet::Module.find without environment

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -13,7 +13,8 @@ class Hiera
       def load_module_config(module_name, environment)
         default_config = {:hierarchy => ["common"]}
 
-        mod = Puppet::Module.find(module_name, environment)
+        mod = Puppet::Module.find(module_name) unless  
+              Puppet::Module.find(module_name, environment)
 
         return default_config unless mod
 

--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -13,8 +13,7 @@ class Hiera
       def load_module_config(module_name, environment)
         default_config = {:hierarchy => ["common"]}
 
-        mod = Puppet::Module.find(module_name) unless  
-              Puppet::Module.find(module_name, environment)
+        mod = Puppet::Module.find(module_name) unless Puppet::Module.find(module_name, environment)
 
         return default_config unless mod
 


### PR DESCRIPTION
Allow fallback to Puppet::Module.find when find with environment fails.  Enables easier development (ex: when modulepath is specified on the command line).