### PR TITLE
Fix/config not deserialized

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -25,7 +25,7 @@ class Hiera
           Hiera.debug("Reading config from %s file" % module_config)
           config = load_data(module_config)
         end
-        
+      
         config["path"] = path
 
         default_config.merge(config)
@@ -35,7 +35,11 @@ class Hiera
         return {} unless File.exist?(path)
 
         @cache.read(path, Hash, {}) do |data|
-          YAML.load(data)
+          if path.end_with? "/hiera.yaml"
+            YAML.load(data, deserialize_symbols: true)
+          else
+            YAML.load(data)
+          end
         end
       end
 


### PR DESCRIPTION
safe_yaml is used by default during load of all data from YAML files within puppet.

When puppet module_data loads hiera.yaml from the module it will safe-load the :hierarchy symbol as string ":hierarchy".  This prevents anything other than common.yaml from being imported into the module's configuration.

This patch loads only files matching hiera.yaml with de-serialization enabled.  Deserializing all symbols could cause undesired operation including increases in memory usage.

Puppet version 4.1.0