### PR TITLE
fix parse error introduced in GH-24

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -36,7 +36,7 @@ class Hiera
 
         @cache.read(path, Hash, {}) do |data|
           if path.end_with? "/hiera.yaml"
-            YAML.load(data, deserialize_symbols: true)
+            YAML.load(data, deserialize_symbols => true)
           else
             YAML.load(data)
           end


### PR DESCRIPTION
The pull request #24 introduced a parse error. This is no valid ruby syntax. This PR fixes this.