### PR TITLE
fix error that mod is nil if unless matches in load_module_config

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -13,7 +13,7 @@ class Hiera
       def load_module_config(module_name, environment)
         default_config = {:hierarchy => ["common"]}
 
-        mod = Puppet::Module.find(module_name) unless Puppet::Module.find(module_name, environment)
+        mod = Puppet::Module.find(module_name, environment) || Puppet::Module.find(module_name)
 
         return default_config unless mod
 


### PR DESCRIPTION
This does not work as intended in ruby. Please see this example:

ruby 2.1.3:
```
2.1.3 :001 > a = 'eins'
 => "eins"
2.1.3 :002 > b = 'zwo'
 => "zwo"
2.1.3 :003 >  c = a unless b
 => nil
2.1.3 :004 >
```
Even though you want c = b, c = nil.

Tested it with 1.8.7 as well. Same behavior.