### PR TITLE
make deserialize_symbols a symbol

### DIFF
--- a/lib/hiera/backend/module_data_backend.rb
+++ b/lib/hiera/backend/module_data_backend.rb
@@ -36,7 +36,7 @@ class Hiera
 
         @cache.read(path, Hash, {}) do |data|
           if path.end_with? "/hiera.yaml"
-            YAML.load(data, deserialize_symbols => true)
+            YAML.load(data, :deserialize_symbols => true)
           else
             YAML.load(data)
           end


### PR DESCRIPTION
This is a fix for #26 . Of course deserialize_symbols needs to be a symbol, the ':' slipped somehow. Sorry for this.